### PR TITLE
Fix Boolean type not existing

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -30,7 +30,7 @@ module Sinatra
         return String(param) if type == String
         return Array(param.split(options[:delimiter] || ",")) if type == Array
         return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
-        return ((/(false|f|no|n|0)$/i === param) ? false : (/(true|t|yes|y|1)$/i === param) ? true : nil) if type == Boolean
+        return ((/(false|f|no|n|0)$/i === param) ? false : (/(true|t|yes|y|1)$/i === param) ? true : nil) if type == :boolean
         return nil
       end
 


### PR DESCRIPTION
I changed the Boolean parameter from a reference to a class (which doesn't exist) to the `:boolean` symbol. I chose doing it this way because I didn't want to pollute the main namespace with an empty Boolean module.

Please let me know if you'd prefer another approach for more consistency.
