### PR TITLE
Check if content_type exists before converting to json

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -13,7 +13,7 @@ module Sinatra
         validate!(params[name], options)
       rescue
         error = "Invalid parameter, #{name}"
-        if content_type.match(mime_type(:json))
+        if content_type && content_type.match(mime_type(:json))
           error = {message: error}.to_json
         end
 


### PR DESCRIPTION
I ran into an issue where if `content_type` is nil, I would get 500 errors. Checking that `content_type` is not nil before casting to JSON stops these errors.
