### PR TITLE
Min and max length for parameters

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -62,13 +62,13 @@ module Sinatra
                   Array(value).include?(param)
                 end
           when :min
-            raise InvalidParameterError unless value <= param
+            raise InvalidParameterError unless param.nil? || value <= param
           when :max
-            raise InvalidParameterError unless value >= param
+            raise InvalidParameterError unless param.nil? || value >= param
           when :min_length
-            raise InvalidParameterError unless value <= param.length
+            raise InvalidParameterError unless param.nil? || value <= param.length
           when :max_length
-            raise InvalidParameterError unless value >= param.length
+            raise InvalidParameterError unless param.nil? || value >= param.length
         end
       end
     end


### PR DESCRIPTION
Any parameter type that responds to `#length` can use this validation, including Strings and Arrays. Values are inclusive, so `max_length: 25` will validate on an a value of length 25, but not length 26.

This validation only runs if the parameter is not nil. To ensure it's not nil, `required: true` is needed.
