### PR TITLE
Skip some validations when param is nil

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -51,16 +51,16 @@ module Sinatra
             when :is
               raise InvalidParameterError unless value === param
             when :in, :within, :range
-              raise InvalidParameterError unless case value
+              raise InvalidParameterError unless param.nil? || case value
                   when Range
                     value.include?(param)
                   else
                     Array(value).include?(param)
                   end
             when :min
-              raise InvalidParameterError unless value <= param
+              raise InvalidParameterError unless param.nil? || value <= param
             when :max
-              raise InvalidParameterError unless value >= param
+              raise InvalidParameterError unless param.nil? || value >= param
           end
         end
       end


### PR DESCRIPTION
I was running into some cases where I'd have an optional parameter that also had a `:in` validation:

`param :foo, String, in: %w[a b c]`

If I left off the parameter (because it was optional), the validation would fail. I had changed it to this line to make it work:

`param :foo, String, in: %w[a, b, c] + [nil]`

But in the end I think it makes more sense for the validation to only run if the param is non-nil.
