### PR TITLE
For `in` validations on Array parameters, validate each member of the array

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -76,7 +76,7 @@ module Sinatra
       # If the param is an Enumerable (including Array), validate each member
       case param
       when Enumerable
-        param.each { |entry| proc.call(entry) }
+        param.all? { |entry| proc.call(entry) }
       else
         proc.call(param)
       end


### PR DESCRIPTION
I have a parameter that's an Array, but each member needs to pass the `in` validation. This change will do the `in` validation on each member of the array parameter, instead of on the array as a whole.
