### PR TITLE
Fixes for JSON post bodies

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -32,8 +32,23 @@ module Sinatra
       return Time.parse(param) if type == Time
       return Date.parse(param) if type == Date
       return DateTime.parse(param) if type == DateTime
-      return Array(param.split(options[:delimiter] || ",")) if type == Array
-      return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
+
+      if type == Array
+        if param.is_a?(Array)
+          return param
+        else
+          return Array(param.split(options[:delimiter] || ","))
+        end
+      end
+
+      if type == Hash
+        if param.is_a?(Hash)
+          return param
+        else
+          return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}]
+        end
+      end
+
       return ((param == false || /(false|f|no|n|0)$/i === param) ? false : (param == true || /(true|t|yes|y|1)$/i === param) ? true : nil) if type == TrueClass || type == FalseClass || type == :boolean
       return nil
     end


### PR DESCRIPTION
I found a Rack middleware that adds JSON post bodies to the `params` hash. This pull request fixes some of the gotchas when dealing with already parsed JSON.

So far, I've only found one issue that needed fixing:
- Don't coerce Arrays and Hashes if they're already that type from JSON.parse

Obtaining the Rack middleware:

Gemfile:

``` ruby
gem 'rack-contrib', git: 'git@github.com:rack/rack-contrib', ref: 'b7237381e412852435d87100a37add67b2cfbb63'
```

Sinatra app:

``` ruby
require 'sinatra/base'
require 'rack/contrib/post_body_content_type_parser'
class MyApp < Sinatra::Base
  use Rack::PostBodyContentTypeParser
  ...
```

And JSON will be automatically placed in the `params` hash on POST routes.

It needs git because there was a bug with `Content-type:application/json;charset=UTF-8` where it wouldn't recognize that content-type correctly. This fix was merged after the last release of rack-contrib. I'm personally using that specific ref because it's the commit that fixed the bug, and the latest commit for that file.
