### PR TITLE
Add an `after_validate` block option

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -12,6 +12,7 @@ module Sinatra
         params[name] = coerce(params[name], type, options) || options[:default]
         params[name] = options[:transform].to_proc.call(params[name]) if options[:transform]
         validate!(params[name], options)
+        params[name] = options[:after_validate].to_proc.call(params[name]) if options[:after_validate]
       rescue
         error = "Invalid parameter, #{name}"
         if content_type && content_type.match(mime_type(:json))


### PR DESCRIPTION
I have an array parameter that I need to run operations on each element after splitting them. Since splitting is performed in the validation step, I needed a transform block that would run after validation.

This pull request adds an `after_validate` parameter that takes a block and runs just like `transform`, but after validation.
