### PR TITLE
Convert boolean params to string before validating against regex

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -34,7 +34,7 @@ module Sinatra
       return DateTime.parse(param) if type == DateTime
       return Array(param.split(options[:delimiter] || ",")) if type == Array
       return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
-      return ((param == false || /(false|f|no|n|0)$/i === param.to_s) ? false : (param == true || /(true|t|yes|y|1)$/i === param.to_s) ? true : nil) if type == TrueClass || type == FalseClass || type == :boolean
+      return (/(false|f|no|n|0)$/i === param.to_s ? false : (/(true|t|yes|y|1)$/i === param.to_s ? true : nil)) if type == TrueClass || type == FalseClass || type == :boolean
       return nil
     end
 


### PR DESCRIPTION
This fixes the following case in JSON post bodies:

``` javascript
{"boolean_param": 0}
```

The param would not be parsed as false in this case because 0 is an integer.
