### PR TITLE
Custom error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Passing a `default` option will provide a default value for a parameter if none 
 
 Use the `transform` option to take even more of the business logic of parameter I/O out of your code. Anything that responds to `to_proc` (including Procs and symbols) will do.
 
+### Custom Error Codes
+
+By default, responses will return a `406` when a validation error occurs. You can opt to respond with a different error by passing an `error` option:
+
+```ruby
+param :sort, String, error: 400
+```
+
 ## Next Steps
 
 - [Design by contract](http://en.wikipedia.org/wiki/Design_by_contract) like this is great for developers, and with a little meta-programming, it could probably be exposed to users as well. The self-documenting dream of [Hypermedia folks](http://twitter.com/#!/steveklabnik) could well be within reach.

--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -7,6 +7,8 @@ module Sinatra
   module Param
     class InvalidParameterError < StandardError; end
 
+    DEFAULT_ERROR_CODE = 406
+
     def param(name, type, options = {})
       begin
         params[name] = coerce(params[name], type, options) || options[:default]
@@ -18,11 +20,13 @@ module Sinatra
           error = {message: error}.to_json
         end
 
-        halt 406, error
+        halt (options[:error] || DEFAULT_ERROR_CODE), error
       end
     end
 
     def one_of(*names)
+      options = names.last.is_a?(::Hash) ? names.pop : {}
+
       count = 0
       names.each do |name|
         if params[name] and present?(params[name])
@@ -34,7 +38,7 @@ module Sinatra
             error = {message: error}.to_json
           end
 
-          halt 406, error
+          halt (options[:error] || DEFAULT_ERROR_CODE), error
         end
       end
     end

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -132,6 +132,11 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/validation/error_code' do
+    param :arg, String, required: true, error: 400
+    params.to_json
+  end
+
   get '/choice' do
     param :a, String
     param :b, String
@@ -142,5 +147,9 @@ class App < Sinatra::Base
     {
       message: 'OK'
     }.to_json
+  end
+
+  get '/choice/error_code' do
+    one_of(:a, :b, :c, error: 400)
   end
 end

--- a/spec/parameter_sets_spec.rb
+++ b/spec/parameter_sets_spec.rb
@@ -29,5 +29,11 @@ describe 'Parameter Sets' do
         end
       end
     end
+
+    it 'permits a custom error code' do
+      get '/choice/error_code', a: 1, b: 2 do |response|
+        response.status.should eq(400)
+      end
+    end
   end
 end

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -171,4 +171,13 @@ describe 'Parameter Validations' do
       end
     end
   end
+
+  describe 'custom error code' do
+    it 'returns a 400 on requests that define an error code' do
+      get('/validation/error_code') do |response|
+        response.status.should eq(400)
+        JSON.parse(response.body)['message'].should eq('Invalid parameter, arg')
+      end
+    end
+  end
 end


### PR DESCRIPTION
I wanted the ability to change the response returned on parameter failures, this change permits an error argument to the `param` method:

``` ruby
param :sort, required: true, error: 400
```

406 remains the default
