### PR TITLE
added rack-test as a dev dependency

### DIFF
--- a/sinatra-param.gemspec
+++ b/sinatra-param.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rack-test"
   s.add_development_dependency "simplecov"
 
   s.files         = Dir["./**/*"].reject { |file| file =~ /\.\/(bin|log|pkg|script|spec|test|vendor)/ }


### PR DESCRIPTION
Looks like rack-test was dropped as a dev dependency as I got this when running the tests off 1.0:

```
/Projects/sinatra-param/spec/spec_helper.rb:12:in `require': cannot load such file -- rack/test (LoadError)
```
