### PR TITLE
ignore timezone in time coercian tests

### DIFF
--- a/spec/parameter_type_coercion_spec.rb
+++ b/spec/parameter_type_coercion_spec.rb
@@ -32,7 +32,7 @@ describe 'Parameter Types' do
     it 'coerces time' do
       get('/coerce/time', arg: '20130117') do |response|
         response.status.should == 200
-        JSON.parse(response.body)['arg'].should eq('2013-01-17 00:00:00 -0500')
+        JSON.parse(response.body)['arg'].should match(/2013-01-17 00:00:00/)
       end
     end
   end


### PR DESCRIPTION
The Time coercian test is currently timezone sensitive. In other words, the tests fail when run on a machine outside of the timezone this test was authored. This patch ignores the timezone in the coerced time string.
