### PR TITLE
responses should return 400 instead of 500 when inputs can't be coerced

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -56,18 +56,22 @@ module Sinatra
     private
 
     def coerce(param, type, options = {})
-      return nil if param.nil?
-      return param if (param.is_a?(type) rescue false)
-      return Integer(param) if type == Integer
-      return Float(param) if type == Float
-      return String(param) if type == String
-      return Time.parse(param) if type == Time
-      return Date.parse(param) if type == Date
-      return DateTime.parse(param) if type == DateTime
-      return Array(param.split(options[:delimiter] || ",")) if type == Array
-      return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
-      return (/(false|f|no|n|0)$/i === param.to_s ? false : (/(true|t|yes|y|1)$/i === param.to_s ? true : nil)) if type == TrueClass || type == FalseClass || type == Boolean
-      return nil
+      begin
+        return nil if param.nil?
+        return param if (param.is_a?(type) rescue false)
+        return Integer(param) if type == Integer
+        return Float(param) if type == Float
+        return String(param) if type == String
+        return Time.parse(param) if type == Time
+        return Date.parse(param) if type == Date
+        return DateTime.parse(param) if type == DateTime
+        return Array(param.split(options[:delimiter] || ",")) if type == Array
+        return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
+        return (/(false|f|no|n|0)$/i === param.to_s ? false : (/(true|t|yes|y|1)$/i === param.to_s ? true : nil)) if type == TrueClass || type == FalseClass || type == Boolean
+        return nil
+      rescue ArgumentError
+        raise InvalidParameterError, "'#{param}' is not a valid #{type}"
+      end
     end
 
     def validate!(param, options)

--- a/spec/parameter_type_coercion_spec.rb
+++ b/spec/parameter_type_coercion_spec.rb
@@ -17,6 +17,13 @@ describe 'Parameter Types' do
         JSON.parse(response.body)['arg'].should eq(1234)
       end
     end
+
+    it 'returns 400 on requests when integer is invalid' do
+      get('/coerce/integer', arg: '123abc') do |response|
+        response.status.should == 400
+        JSON.parse(response.body)['message'].should eq('Invalid Parameter: arg')
+      end
+    end
   end
 
   describe 'Float' do
@@ -24,6 +31,13 @@ describe 'Parameter Types' do
       get('/coerce/float', arg: '1234') do |response|
         response.status.should == 200
         JSON.parse(response.body)['arg'].should eq(1234.0)
+      end
+    end
+
+    it 'returns 400 on requests when float is invalid' do
+      get('/coerce/float', arg: '123abc') do |response|
+        response.status.should == 400
+        JSON.parse(response.body)['message'].should eq('Invalid Parameter: arg')
       end
     end
   end
@@ -35,6 +49,13 @@ describe 'Parameter Types' do
         JSON.parse(response.body)['arg'].should match(/2013-01-17 00:00:00/)
       end
     end
+
+    it 'returns 400 on requests when time is invalid' do
+      get('/coerce/time', arg: '123abc') do |response|
+        response.status.should == 400
+        JSON.parse(response.body)['message'].should eq('Invalid Parameter: arg')
+      end
+    end
   end
 
   describe 'Date' do
@@ -44,6 +65,13 @@ describe 'Parameter Types' do
         JSON.parse(response.body)['arg'].should eq('2013-01-17')
       end
     end
+
+    it 'returns 400 on requests when date is invalid' do
+      get('/coerce/date', arg: 'abc') do |response|
+        response.status.should == 400
+        JSON.parse(response.body)['message'].should eq('Invalid Parameter: arg')
+      end
+    end
   end
 
   describe 'DateTime' do
@@ -51,6 +79,13 @@ describe 'Parameter Types' do
       get('/coerce/datetime', arg: '20130117') do |response|
         response.status.should == 200
         JSON.parse(response.body)['arg'].should eq('2013-01-17T00:00:00+00:00')
+      end
+    end
+
+    it 'returns 400 on requests when datetime is invalid' do
+      get('/coerce/datetime', arg: 'abc') do |response|
+        response.status.should == 400
+        JSON.parse(response.body)['message'].should eq('Invalid Parameter: arg')
       end
     end
   end


### PR DESCRIPTION
I wrapped the `coerce` method in a try/catch and raised the `InvalidParameterError` on an unsuccessful coercion.  I figured this is what should happen, right?

I also added some new tests for extra flavor.
