### PR TITLE
skip transformations on nil values

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -19,7 +19,7 @@ module Sinatra
       begin
         params[name] = coerce(params[name], type, options)
         params[name] = (options[:default].call if options[:default].respond_to?(:call)) || options[:default] if params[name].nil? and options[:default]
-        params[name] = options[:transform].to_proc.call(params[name]) if options[:transform]
+        params[name] = options[:transform].to_proc.call(params[name]) if params[name] and options[:transform]
         validate!(params[name], options)
       rescue InvalidParameterError => exception
         if options[:raise] or (settings.raise_sinatra_param_exceptions rescue false)

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -100,6 +100,11 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/transform/required' do
+    param :order, String, required: true, transform: :upcase
+    params.to_json
+  end
+
   get '/validation/required' do
     param :arg, String, required: true
     params.to_json

--- a/spec/parameter_transformations_spec.rb
+++ b/spec/parameter_transformations_spec.rb
@@ -24,5 +24,12 @@ describe 'Parameter Transformations' do
         JSON.parse(response.body)['order'].should == 'ASC'
       end
     end
+
+    it 'skips transformations when the value is nil' do
+      get('/transform/required') do |response|
+        response.status.should == 400
+        JSON.parse(response.body)['message'].should eq('Invalid Parameter: order')
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes an edge case that I recently uncovered while upgrading to the latest version of the gem. Prior to this change, transformations were being attempted against null values and resulting in exceptions like:

```
NoMethodError:
   undefined method `upcase' for nil:NilClass
```

I believe the test covers the only scenario under which this would occur.
