### PR TITLE
Add convenience rake task to run tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,11 @@ task :build => "#{gemspec.full_name}.gem"
 file "#{gemspec.full_name}.gem" => gemspec.files + ["sinatra-param.gemspec"] do
   system "gem build sinatra-param.gemspec"
 end
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+
+  task :default => :spec
+rescue LoadError
+end


### PR DESCRIPTION
Add convenience rake task to run tests

Added `rake spec`
And made it the default task so running `rake` runs the tests

I just thing this is a good practice.