### PR TITLE
Allow one_of to accept groups of parameters

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -38,9 +38,9 @@ module Sinatra
 
     def one_of(*args)
       options = args.last.is_a?(Hash) ? args.pop : {}
-      names = args.collect(&:to_s)
+      names = args
 
-      return unless names.length > 2
+      return unless names.length >= 2
 
       begin
         validate_one_of!(params, names, options)
@@ -118,13 +118,20 @@ module Sinatra
       end
     end
 
-    def validate_one_of!(params, names, options)
-      raise InvalidParameterError, "Parameters #{names.join(', ')} are mutually exclusive" if names.count{|name| present?(params[name])} > 1
+    def validate_one_of!(params, groups, options)
+      if groups.select {|names| params_present?(params, names) }.length > 1
+        raise InvalidParameterError, "Parameters #{groups.collect(&:inspect).join(', ')} are mutually exclusive"
+      end
     end
 
     # ActiveSupport #present? and #blank? without patching Object
     def present?(object)
       !blank?(object)
+    end
+
+    def params_present?(params, names)
+      names = Array(names)
+      names.select{|name| present?(params[name.to_s]) }.length == names.length
     end
 
     def blank?(object)

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -197,6 +197,18 @@ class App < Sinatra::Base
     }.to_json
   end
 
+  get '/choice/groups' do
+    param :a, String
+    param :b, String
+    param :c, String
+
+    one_of [:a, :b], [:a, :c]
+
+    {
+      message: 'OK'
+    }.to_json
+  end
+
   get '/raise/validation/required' do
     param :arg, String, required: true, raise: true
     params.to_json

--- a/spec/parameter_exclusivity_multiple_spec.rb
+++ b/spec/parameter_exclusivity_multiple_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'Parameter Sets' do
+  describe 'one_of *groups' do
+    it 'returns 400 on requests that contain more than one mutually exclusive parameter' do
+      params = [
+        {a: 1, b: 2, c: 3}
+      ]
+
+      params.each do |param|
+        get('/choice/groups', param) do |response|
+          expect(response.status).to eql 400
+          expect(JSON.parse(response.body)['message']).to match(/mutually exclusive/)
+        end
+      end
+    end
+
+    it 'returns successfully for requests that have one parameter' do
+      params = [
+        {a: 1},
+        {b: 2},
+        {c: 3},
+        {a: 1, b: 2},
+        {a: 1, c: 3},
+        {b: 2, c: 3}
+      ]
+
+      params.each do |param|
+        get('/choice/groups', param) do |response|
+          expect(response.status).to eql 200
+          expect(JSON.parse(response.body)['message']).to match(/OK/)
+        end
+      end
+    end
+
+    it 'returns successfully for requests that have no parameter' do
+      get('/choice/groups') do |response|
+        expect(response.status).to eql 200
+        expect(JSON.parse(response.body)['message']).to match(/OK/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`one_of [:a, :b], [:a, :c]` should be read as `one_of (:a and :b),  (:a and :c)`