### PR TITLE
add support for at_least_one_of validations

### DIFF
--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -190,7 +190,7 @@ class App < Sinatra::Base
     param :b, String
     param :c, String
 
-    one_of :a
+    only_one_of :a
 
     {
       message: 'OK'
@@ -202,7 +202,7 @@ class App < Sinatra::Base
     param :b, String
     param :c, String
 
-    one_of :a, :b
+    only_one_of :a, :b
 
     {
       message: 'OK'
@@ -214,12 +214,25 @@ class App < Sinatra::Base
     param :b, String
     param :c, String
 
-    one_of :a, :b, :c
+    only_one_of :a, :b, :c
 
     {
       message: 'OK'
     }.to_json
   end
+
+  get '/atleast' do
+    param :a, String
+    param :b, String
+    param :c, String
+
+    at_least_one_of :a, :b, :c
+
+    {
+      message: 'OK'
+    }.to_json
+  end
+
 
   get '/raise/validation/required' do
     param :arg, String, required: true, raise: true

--- a/spec/parameter_exclusivity_spec.rb
+++ b/spec/parameter_exclusivity_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Parameter Sets' do
-  describe 'one_of' do
+  describe 'only_one_of' do
     it 'returns 400 on requests that contain more than one mutually exclusive parameter' do
       params = [
         {a: 1, b: 2},
@@ -49,6 +49,31 @@ describe 'Parameter Sets' do
           expect(response.status).to eql 200
           expect(JSON.parse(response.body)['message']).to match(/OK/)
         end
+      end
+    end
+  end
+
+  describe 'at_only_one_of' do
+    it 'returns 200 on requests that contain at least one parameter' do
+      params = [
+        {a: 1, b: 2},
+        {b: 2, c: 3},
+        {a: 1, b: 2, c: 3}
+      ]
+
+      params.each do |param|
+        get('/atleast', param) do |response|
+          expect(response.status).to eql 200
+        end
+      end
+    end
+
+    it 'returns 400 on requests that do not contain any required parameters' do
+      params = {d: 1}
+
+      get('/atleast', params) do |response|
+        expect(response.status).to eql 400
+        expect(JSON.parse(response.body)['message']).to match(/At least one of the following parameters/)
       end
     end
   end


### PR DESCRIPTION
This adds a new method called `at_least_one_of` for scenarios where you want to require a minimum of one of a set of parameters. Usage would be like this:

```ruby
get '/atleast' do
  param :a, String
  param :b, String
  param :c, String

  at_least_one_of :a, :b, :c
  # do something with the parameters
end
```

If none of `a`, `b`, or `c` are passed, an error is returned with the message: `At least one of the following parameters is required: a, b, c`.

With this addition, the method `one_of` becomes somewhat ambiguously named and could create confusion so I decided to rename it to `only_one_of`. It's still aliased as `one_of`, so it's not a breaking change.

I haven't added documentation yet as I wasn't sure if you'd be receptive to this change. I'm happy to document it if you think it's worth including.