### PR TITLE
Adds `if` check

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Encapsulate business logic in a consistent way with validations. If a parameter 
 - `in`, `within`, `range`
 - `min` / `max`
 - `format`
+- `if`
 
 ### Defaults and Transformations
 

--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -15,6 +15,7 @@ module Sinatra
       name = name.to_s
 
       return unless params.member?(name) or options[:default] or options[:required]
+      return if options[:if] && options[:if].call == false
 
       begin
         params[name] = coerce(params[name], type, options)

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -160,6 +160,11 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/validation/if' do
+    param :arg, Integer, if: ->{ params[:arg2] == 'foo' }
+    params.to_json
+  end
+
   get '/validation/range' do
     param :arg, Integer, range: 1..10
     params.to_json

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -102,6 +102,21 @@ describe 'Parameter Validations' do
     end
   end
 
+  describe 'if' do
+    it 'validates when call evaluates to true' do
+      get('/validation/if', arg: 'foobar', arg2: 'foo') do |response|
+        expect(response.status).to eq(400)
+        expect(JSON.parse(response.body)['message']).to eq("'foobar' is not a valid Integer")
+      end
+    end
+
+    it 'does not validate when call evaluates to false' do
+      get('/validation/if', arg: 'foobar') do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   describe 'within' do
     it 'returns 400 on requests with a value outside the range' do
       get('/validation/within', arg: 20) do |response|


### PR DESCRIPTION
Allows a lambda to be passed in as `if`, and all validations for that param will be skipped if it evaluates to `false`.

I didn't see any style guides or PR guidelines, but if I've missed either please let me know so I can correct things.