### PR TITLE
send text/plain on non-JSON responses

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -31,6 +31,8 @@ module Sinatra
 
         if content_type and content_type.match(mime_type(:json))
           error = {message: error, errors: {name => exception.message}}.to_json
+        else
+          content_type 'text/plain'
         end
 
         halt 400, error

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -261,4 +261,9 @@ class App < Sinatra::Base
       message: 'OK'
     }.to_json
   end
+
+  get '/xml' do
+    content_type :xml
+    param :a, Integer, within: 1..10, required: true
+  end
 end

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -191,4 +191,18 @@ describe 'Parameter Validations' do
       end
     end
   end
+
+  context 'content-type header' do
+    it 'returns application/json for JSON APIs' do
+      get('/validation/max_length', arg: 'reallylongstringlongerthanmax') do |response|
+        expect(response.headers['Content-Type']).to eq('application/json')
+      end
+    end
+
+    it 'returns text/plain for non-JSON APIs' do
+      get('/xml', arg: 'reallylongstringlongerthanmax') do |response|
+        expect(response.headers['Content-Type']).to include('text/plain')
+      end
+    end
+  end
 end


### PR DESCRIPTION
I stumbled on this recently in one of our APIs and was surprised that I never realized it before. For non-JSON APIs (which are handled properly) the response is `text/plain` but the actual `Content-Type` of the response is not altered and has the potential to be incorrect. 

In our circumstance, we have an API that returns XML but when there's errors the content type is `application/xml` but the actual body of the response is of the pattern `"Parameter is required"`. I know this library heavily favors JSON, but seems like the proper way to handle non-JSON responses.
