### PR TITLE
Format Validation for Arrays of Strings

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -119,8 +119,18 @@ module Sinatra
             param.nil?
           end
         when :format
-          raise InvalidParameterError, "Parameter must be a string if using the format validation" unless param.kind_of?(String)
-          raise InvalidParameterError, "Parameter must match format #{value}" unless param =~ value
+          raise InvalidParameterError, "Parameter must be a string if using the format validation" unless case param
+          when Array
+            param.all? { |c| c.kind_of?(String) }
+          else
+            param.kind_of?(String)
+          end
+          raise InvalidParameterError, "Parameter must match format #{value}" unless case param
+          when Array
+            param.all? { |c| c =~ value }
+          else
+            param =~ value
+          end
         when :is
           raise InvalidParameterError, "Parameter must be #{value}" unless param === value
         when :in, :within, :range

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -140,6 +140,11 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/validation/format/array' do
+    param :arg, Array, format: /hello/
+    params.to_json
+  end
+
   get '/validation/format/hello' do
     param :arg, String, format: /hello/
     params.to_json

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -70,6 +70,31 @@ describe 'Parameter Validations' do
         expect(response.status).to eq(400)
       end
     end
+
+    it 'returns 200 on requests when value is an array' do
+      get('/validation/format/array', arg: 'hello') do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'returns 200 on requests when the array is empty' do
+      get('/validation/format/array', arg: '') do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'returns 200 on requests when value is array and they all match' do
+      get('/validation/format/array', arg: 'hello,hello,hello') do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'returns 400 on requests when value is array and they do not all match' do
+      get('/validation/format/array', arg: 'hello,no,hello') do |response|
+        expect(response.status).to eq(400)
+      end
+    end
+
   end
 
   describe 'is' do


### PR DESCRIPTION
Thought it would be useful to be able to apply the same format validation you have for Strings to arrays of Strings as well. Each String in the array is checked against the format, and all of them have to match in order for the validation to pass.

Usage Example:

``` ruby
param :strings, Array, format: /regex/
```
