### PR TITLE
Update README exception documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ By default, when a parameter precondition fails, `Sinatra::Param` will `halt 400
 
 ```json
 {
-    "message": "Invalid parameter, order",
+    "message": "Parameter must be within [\"ASC\", \"DESC\"]",
     "errors": {
-        "order": "Param must be within [\"ASC\", \"DESC\"]"
+        "order": "Parameter must be within [\"ASC\", \"DESC\"]"
     }
 }
 ```


### PR DESCRIPTION
Updates the [exception section](https://github.com/mattt/sinatra-param#exceptions) of the README to reflect changes in 5cf103c (see #55)
