### PR TITLE
allows :in, :within, :range validations to be used on Array params

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -126,9 +126,19 @@ module Sinatra
         when :in, :within, :range
           raise InvalidParameterError, "Parameter must be within #{value}" unless param.nil? || case value
           when Range
-            value.include?(param)
+            case param
+            when Array
+              param.all? { |element| value.include?(element) }
+            else
+              value.include?(param)
+            end
           else
-            Array(value).include?(param)
+            case param
+            when Array
+              (param - Array(value)).empty?
+            else
+              Array(value).include?(param)
+            end
           end
         when :min
           raise InvalidParameterError, "Parameter cannot be less than #{value}" unless param.nil? || value <= param

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -155,13 +155,28 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/validation/in/array' do
+    param :arg, Array, in: ['ASC', 'DESC']
+    params.to_json
+  end
+
   get '/validation/within' do
     param :arg, Integer, within: 1..10
     params.to_json
   end
 
+  get '/validation/within/array' do
+    param :arg, Array, within: 1..10, transform: ->(a) { a.map(&:to_i) }
+    params.to_json
+  end
+
   get '/validation/range' do
     param :arg, Integer, range: 1..10
+    params.to_json
+  end
+
+  get '/validation/range/array' do
+    param :arg, Array, range: 1..10, transform: ->(a) { a.map(&:to_i) }
     params.to_json
   end
 

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -100,6 +100,21 @@ describe 'Parameter Validations' do
         expect(response.status).to eq(200)
       end
     end
+
+    describe 'for Arrays' do
+      it 'returns 400 on requests with any value not in the set' do
+        get('/validation/in/array', arg: 'MISC,ASC') do |response|
+          expect(response.status).to eq(400)
+          expect(JSON.parse(response.body)['message']).to eq("Parameter must be within [\"ASC\", \"DESC\"]")
+        end
+      end
+
+      it 'returns 200 on requests with all values in the set' do
+        get('/validation/in/array', arg: 'ASC,DESC') do |response|
+          expect(response.status).to eq(200)
+        end
+      end
+    end
   end
 
   describe 'within' do
@@ -115,6 +130,21 @@ describe 'Parameter Validations' do
         expect(response.status).to eq(200)
       end
     end
+
+    describe 'for Arrays' do
+      it 'returns 400 on requests with any value outside the range' do
+        get('/validation/within/array', arg: [20,5]) do |response|
+          expect(response.status).to eq(400)
+          expect(JSON.parse(response.body)['message']).to eq("Parameter must be within 1..10")
+        end
+      end
+
+      it 'returns 200 on requests with all values within the range' do
+        get('/validation/within/array', arg: [5,10]) do |response|
+          expect(response.status).to eq(200)
+        end
+      end
+    end
   end
 
   describe 'range' do
@@ -128,6 +158,21 @@ describe 'Parameter Validations' do
     it 'returns 200 on requests within the range' do
       get('/validation/range', arg: 10) do |response|
         expect(response.status).to eq(200)
+      end
+    end
+
+    describe 'for Arrays' do
+      it 'returns 400 on requests with any value outside the range' do
+        get('/validation/range/array', arg: [20,5]) do |response|
+          expect(response.status).to eq(400)
+          expect(JSON.parse(response.body)['message']).to eq("Parameter must be within 1..10")
+        end
+      end
+
+      it 'returns 200 on requests with all values within the range' do
+        get('/validation/range/array', arg: [5,10]) do |response|
+          expect(response.status).to eq(200)
+        end
       end
     end
   end


### PR DESCRIPTION
This makes it possible to support situations such as

```ruby
param :sort_by, Array, in: ['id ASC, 'id DESC, 'name ASC', 'name DESC']
```

Range checks against array elements are also supported, but currently require you to coerce the Array elements manually first:

```ruby
param :arg, Array, within: 1..10, transform: ->(a) { a.map(&:to_i) }
```