### PR TITLE
Support for nested params

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ param :order, String, in: ["ASC", "DESC"], raise: true
 one_of :q, :categories, raise: true
 ```
 
+## Nested Params
+
+Passing a `scope` option will provide validation for nested params, e.g. for GET parameter `q[order_id_eq]=4`:
+
+```ruby
+param :order_id_eq, Integer, scope: :q, min: 1, max: 2147483647
+```
+
 ## Contact
 
 Mattt Thompson ([@mattt](http://twitter.com/mattt))

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -175,6 +175,11 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/validation/scoped/max' do
+    param :arg, Integer, scope: :q, max: 20
+    params.to_json
+  end
+
   get '/validation/min_length' do
     param :arg, String, min_length: 5
     params.to_json

--- a/spec/parameter_raise_spec.rb
+++ b/spec/parameter_raise_spec.rb
@@ -5,7 +5,7 @@ describe 'Exception' do
     it 'should raise error when option is specified' do
       expect {
         get('/raise/validation/required')
-      }.to raise_error
+      }.to raise_error Sinatra::Param::InvalidParameterError
     end
   end
 
@@ -13,13 +13,13 @@ describe 'Exception' do
     params = {a: 1, b: 2, c: 3}
     expect {
       get('/raise/one_of/3', params)
-    }.to raise_error
+    }.to raise_error Sinatra::Param::InvalidParameterError
   end
 
   it 'should raise error when no parameters are specified' do
     params = {}
     expect {
       get('/raise/any_of', params)
-    }.to raise_error
+    }.to raise_error Sinatra::Param::InvalidParameterError
   end
 end

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -160,6 +160,21 @@ describe 'Parameter Validations' do
         expect(response.status).to eq(200)
       end
     end
+
+    context 'nested params' do
+      it 'returns 400 on requests with a value larger than max' do
+        get('/validation/scoped/max', q: { arg: 100 }) do |response|
+          expect(response.status).to eq(400)
+          expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be greater than 20")
+        end
+      end
+
+      it 'returns 200 on requests with a value smaller than max' do
+        get('/validation/scoped/max', q: { arg: 2 }) do |response|
+          expect(response.status).to eq(200)
+        end
+      end
+    end
   end
 
   describe 'min_length' do


### PR DESCRIPTION
This is related to closed issue #33 
Sometimes this is really needed, e.g. if search parameters are nested by API design.
Please consider.
