### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.9.3
+before_install:
+  - gem install bundler


### PR DESCRIPTION
Travis builds have been failing with the following error:

```
NoMethodError: undefined method `spec' for nil:NilClass
```

As there has been no .travis.yml previously the builds were running
with Travis' defaults. This includes an older version of bundler
(1.7.6) that has a bug that causes the above error. This adds a
.travis.yml that updates bundler and avoids the error.

Ruby 1.9.3 is listed as this is the version Travis tests againsst
by default.

With thanks to:

https://github.com/rubygems/rubygems/issues/1419
https://github.com/danmayer/coverband/pull/38
