### PR TITLE
Add optional error handling without exception.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 /doc/
 /rdoc/
 
+.byebug_history
+
 # Environment
 /.bundle/
 /lib/bundler/man/

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --order random
+--require spec_helper.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
+gem 'byebug'
 gemspec

--- a/README.md
+++ b/README.md
@@ -118,6 +118,43 @@ param :y, String
 any_of :x, :y
 ```
 
+### Errors without exception
+
+If you need to consume error with custom business logic (e.g. do not show error one by one but all errors at once). You can do this with this PR.
+
+Set flag to change slightly way how to sinatra param use "bang methods"
+
+
+```ruby
+class AppWithFlash < Sinatra::Base
+  helpers Sinatra::Param
+  
+  configure do
+    set :ruby_best_practice_sinatra_param, true
+  end
+end
+```
+
+after seting up this flag will be modified helper method "param", "one_of" and "any_of" and will be created 3 additional methods "param!", "one_of!" and "any_of!" as it's standard in Ruby community methods with bang character in the end will raise error same as for instance save vs save! in ActiveRecord.
+
+So now param helper do not raise exception and halt execution but return value if error happend otherwise just nil value represent "nothing to show".
+
+```ruby
+error_for_a = param(:a, String)
+```
+
+error_for_a will contain same error message as people are use to to get from standard Sinatra param library.
+
+as bonus we create helper method for collect or errors and remove nil values.
+
+```ruby
+errors = errors_for_params do |errors|
+  param(:a, String)
+  param(:b, String)
+  param(:c, String)
+end
+```
+
 ### Exceptions
 
 By default, when a parameter precondition fails, `Sinatra::Param` will `halt 400` with an error message:

--- a/sinatra-param.gemspec
+++ b/sinatra-param.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sinatra", "~> 1.3"
 
   s.add_development_dependency "rake"
+  s.add_development_dependency "rack"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "simplecov"

--- a/spec/dummy/app_with_flash.rb
+++ b/spec/dummy/app_with_flash.rb
@@ -4,12 +4,13 @@ require 'date'
 require 'time'
 require 'json'
 
-class App < Sinatra::Base
+class AppWithFlash < Sinatra::Base
   helpers Sinatra::Param
-
+  
   configure do
     set :show_exceptions, false
     set :raise_errors, true
+    set :ruby_best_practice_sinatra_param, true
   end
 
   before do
@@ -17,180 +18,180 @@ class App < Sinatra::Base
   end
 
   get '/' do
-    param :a, String
-    param :b, String, required: true
-    param :c, String, default: 'test'
-    param :d, String
+    param! :a, String
+    param! :b, String, required: true
+    param! :c, String, default: 'test'
+    param! :d, String
 
     params.to_json
   end
 
   get '/keys/stringify' do
-    param :q, String, transform: :upcase
+    param! :q, String, transform: :upcase
 
     params['q']
   end
 
   get '/coerce/string' do
     params['arg'] = params['arg'].to_i
-    param :arg, String
+    param! :arg, String
     params.to_json
   end
 
   get '/coerce/integer' do
-    param :arg, Integer
+    param! :arg, Integer
     params.to_json
   end
 
   get '/coerce/float' do
-    param :arg, Float
+    param! :arg, Float
     params.to_json
   end
 
   get '/coerce/time' do
-    param :arg, Time
+    param! :arg, Time
     params.to_json
   end
 
   get '/coerce/date' do
-    param :arg, Date
+    param! :arg, Date
     params.to_json
   end
 
   get '/coerce/datetime' do
-    param :arg, DateTime
+    param! :arg, DateTime
     params.to_json
   end
 
   get '/coerce/array' do
-    param :arg, Array
+    param! :arg, Array
     params.to_json
   end
 
   get '/coerce/hash' do
-    param :arg, Hash
+    param! :arg, Hash
     params.to_json
   end
 
   get '/coerce/boolean' do
-    param :arg, Boolean
+    param! :arg, Boolean
     params.to_json
   end
 
   get '/default' do
-    param :sort, String, default: "title"
+    param! :sort, String, default: "title"
     params.to_json
   end
 
   get '/default/hash' do
-    param :attributes, Hash, default: {}
+    param! :attributes, Hash, default: {}
     params.to_json
   end
 
   get '/default/proc' do
-    param :year, Integer, default: proc { 2014 }
+    param! :year, Integer, default: proc { 2014 }
     params.to_json
   end
 
   get '/default/boolean/true' do
-    param :arg, Boolean, default: true
+    param! :arg, Boolean, default: true
     params.to_json
   end
 
   get '/default/boolean/false' do
-    param :arg, Boolean, default: false
+    param! :arg, Boolean, default: false
     params.to_json
   end
 
   get '/transform' do
-    param :order, String, transform: :upcase
+    param! :order, String, transform: :upcase
     params.to_json
   end
 
   get '/transform/required' do
-    param :order, String, required: true, transform: :upcase
+    param! :order, String, required: true, transform: :upcase
     params.to_json
   end
 
   get '/validation/required' do
-    param :arg, String, required: true
+    param! :arg, String, required: true
     params.to_json
   end
 
   get '/validation/blank/string' do
-    param :arg, String, blank: false
+    param! :arg, String, blank: false
   end
 
   get '/validation/blank/array' do
-    param :arg, Array, blank: false
+    param! :arg, Array, blank: false
   end
 
   get '/validation/blank/hash' do
-    param :arg, Hash, blank: false
+    param! :arg, Hash, blank: false
   end
 
   get '/validation/blank/other' do
-    param :arg, Class, blank: false
+    param! :arg, Class, blank: false
   end
 
   get '/validation/nonblank/string' do
-    param :arg, String, blank: true
+    param! :arg, String, blank: true
   end
 
   get '/validation/format/9000' do
-    param :arg, Integer, format: /9000/
+    param! :arg, Integer, format: /9000/
     params.to_json
   end
 
   get '/validation/format/hello' do
-    param :arg, String, format: /hello/
+    param! :arg, String, format: /hello/
     params.to_json
   end
 
   get '/validation/is' do
-    param :arg, String, is: 'foo'
+    param! :arg, String, is: 'foo'
     params.to_json
   end
 
   get '/validation/in' do
-    param :arg, String, in: ['ASC', 'DESC']
+    param! :arg, String, in: ['ASC', 'DESC']
     params.to_json
   end
 
   get '/validation/within' do
-    param :arg, Integer, within: 1..10
+    param! :arg, Integer, within: 1..10
     params.to_json
   end
 
   get '/validation/range' do
-    param :arg, Integer, range: 1..10
+    param! :arg, Integer, range: 1..10
     params.to_json
   end
 
   get '/validation/min' do
-    param :arg, Integer, min: 12
+    param! :arg, Integer, min: 12
     params.to_json
   end
 
   get '/validation/max' do
-    param :arg, Integer, max: 20
+    param! :arg, Integer, max: 20
     params.to_json
   end
 
   get '/validation/min_length' do
-    param :arg, String, min_length: 5
+    param! :arg, String, min_length: 5
     params.to_json
   end
 
   get '/validation/max_length' do
-    param :arg, String, max_length: 10
+    param! :arg, String, max_length: 10
     params.to_json
   end
 
   get '/one_of/1' do
-    param :a, String
-    param :b, String
-    param :c, String
+    param! :a, String
+    param! :b, String
+    param! :c, String
 
     one_of :a
 
@@ -200,9 +201,9 @@ class App < Sinatra::Base
   end
 
   get '/one_of/2' do
-    param :a, String
-    param :b, String
-    param :c, String
+    param! :a, String
+    param! :b, String
+    param! :c, String
 
     one_of :a, :b
 
@@ -212,9 +213,9 @@ class App < Sinatra::Base
   end
 
   get '/one_of/3' do
-    param :a, String
-    param :b, String
-    param :c, String
+    param! :a, String
+    param! :b, String
+    param! :c, String
 
     one_of :a, :b, :c
 
@@ -224,9 +225,9 @@ class App < Sinatra::Base
   end
 
   get '/any_of' do
-    param :a, String
-    param :b, String
-    param :c, String
+    param! :a, String
+    param! :b, String
+    param! :c, String
 
     any_of :a, :b, :c
 
@@ -236,20 +237,22 @@ class App < Sinatra::Base
   end
 
   get '/raise/validation/required' do
-    param :arg, String, required: true, raise: true
+    param! :arg, String, required: true, raise: true
     params.to_json
   end
 
-  get '/flash/validations/required' do
-    param :arg, Integer, required: true, raise: true, min: 12
-
-    expect(flash.keys).to be('')
+  get '/errors/validation/required' do
+    errors = errors_for_params do |errors|
+      errors << param(:arg, Integer, required: true, min: 12, in: 2..100)
+      errors << param(:arg2, Integer, required: true, min: 0, in: 0..100)
+    end
+    errors.to_json
   end
 
   get '/raise/one_of/3' do
-    param :a, String
-    param :b, String
-    param :c, String
+    param! :a, String
+    param! :b, String
+    param! :c, String
 
     one_of :a, :b, :c, raise: true
 
@@ -258,15 +261,39 @@ class App < Sinatra::Base
     }.to_json
   end
 
+  get '/errors/one_of/3' do
+    errors = errors_for_params do |errors|
+      errors << param(:a, String)
+      errors << param(:b, String)
+      errors << param(:c, String)
+
+      errors << one_of(:a, :b, :c)
+    end
+
+    errors.to_json
+  end
+
   get '/raise/any_of' do
-    param :a, String
-    param :b, String
-    param :c, String
+    param! :a, String
+    param! :b, String
+    param! :c, String
 
     any_of :a, :b, :c, raise: true
 
     {
       message: 'OK'
     }.to_json
+  end
+
+  get '/errors/any_of' do
+    errors = errors_for_params do |errors|
+      param(:a, String)
+      param(:b, String)
+      param(:c, String)
+
+      errors << any_of(:a, :b, :c)
+    end
+
+    errors.to_json
   end
 end

--- a/spec/flash/parameter_flash_spec.rb
+++ b/spec/flash/parameter_flash_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe 'Flash' do
+  def app
+    @app = AppWithFlash
+  end
+
+  describe 'set up error' do
+    it 'should return simple json message with all errors' do
+      get('/errors/validation/required', arg: 1, arg2: 0)
+      
+      json_response = JSON.parse(last_response.body)
+
+      expect(json_response[0].keys.first).to eq('arg')
+      expect(json_response[0]['arg']).to include(
+        'Parameter cannot be less than 12',
+        'Parameter must be within 2..100'
+      )
+    end
+  end
+
+  it 'should raise error when more than one parameter is specified' do
+    params = {a: 1, b: 2, c: 3}
+
+    get('/errors/one_of/3', params)
+
+    json_response = JSON.parse(last_response.body)
+    
+    expect(json_response[0]).to eq('Only one of [a, b, c] is allowed')
+  end
+
+  it 'should raise error when no parameters are specified' do
+    params = {}
+    
+    get('/errors/any_of', params)
+
+    json_response = JSON.parse(last_response.body)
+    
+    expect(json_response[0]).to eq('One of parameters [a, b, c] is required')
+  end
+end

--- a/spec/parameter_exclusivity_spec.rb
+++ b/spec/parameter_exclusivity_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Parameter Sets' do
+RSpec.describe 'Parameter Sets' do
   describe 'one_of' do
     it 'returns 400 on requests that contain more than one mutually exclusive parameter' do
       params = [

--- a/spec/parameter_inclusivity_spec.rb
+++ b/spec/parameter_inclusivity_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Parameter Sets' do
+RSpec.describe 'Parameter Sets' do
   describe 'any_of' do
     it 'returns 400 on requests that contain fewer than one required parameter' do
       get('/any_of', {}) do |response|

--- a/spec/parameter_raise_spec.rb
+++ b/spec/parameter_raise_spec.rb
@@ -5,7 +5,7 @@ describe 'Exception' do
     it 'should raise error when option is specified' do
       expect {
         get('/raise/validation/required')
-      }.to raise_error
+      }.to raise_error Sinatra::Param::InvalidParameterError
     end
   end
 
@@ -13,13 +13,13 @@ describe 'Exception' do
     params = {a: 1, b: 2, c: 3}
     expect {
       get('/raise/one_of/3', params)
-    }.to raise_error
+    }.to raise_error Sinatra::Param::InvalidParameterError
   end
 
   it 'should raise error when no parameters are specified' do
     params = {}
     expect {
       get('/raise/any_of', params)
-    }.to raise_error
+    }.to raise_error Sinatra::Param::InvalidParameterError
   end
 end

--- a/spec/parameter_raise_spec.rb
+++ b/spec/parameter_raise_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Exception' do
+RSpec.describe 'Exception' do
   describe 'raise' do
     it 'should raise error when option is specified' do
       expect {

--- a/spec/parameter_spec.rb
+++ b/spec/parameter_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Parameter' do
+RSpec.describe 'Parameter' do
   it 'only sets parameters present in request or with a default value' do
     get('/', a: 'a', b: 'b') do |response|
       response_body = JSON.parse(response.body)

--- a/spec/parameter_transformations_spec.rb
+++ b/spec/parameter_transformations_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Parameter Transformations' do
+RSpec.describe 'Parameter Transformations' do
   describe 'default' do
     it 'sets a default value when none is given' do
       get('/default') do |response|

--- a/spec/parameter_type_coercion_spec.rb
+++ b/spec/parameter_type_coercion_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Parameter Types' do
+RSpec.describe 'Parameter Types' do
   describe 'String' do
     it 'coerces strings' do
       get('/coerce/string', arg: '1234') do |response|

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Parameter Validations' do
+RSpec.describe 'Parameter Validations' do
   describe 'required' do
     it 'returns 400 on requests without required fields' do
       get('/validation/required') do |response|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,9 +12,12 @@ require 'rspec'
 require 'rack/test'
 
 require 'dummy/app'
+require 'dummy/app_with_flash'
 
 def app
   App
 end
 
-include Rack::Test::Methods
+RSpec.configure do |conf|
+  conf.include Rack::Test::Methods
+end


### PR DESCRIPTION
This PR fix several things:

- Fix warning related to last version RSpec
- Fix duplication for spec_helper require statment
- Fix problem with using non bang method for raising exceptions (param raise exception)
- Add ability to handler error within request block