### PR TITLE
Add length validations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Encapsulate business logic in a consistent way with validations. If a parameter 
 - `is`
 - `in`, `within`, `range`
 - `min` / `max`
+- `min_length` / `max_length`
 - `format`
 
 ### Defaults and Transformations


### PR DESCRIPTION
I noticed that the `min_length` and `max_length` validations weren't listed in the README. This pull request just adds them to the list.

If you'd like, I can also take a stab at some comprehensive examples for each validation. I think that would benefit a lot of users. Thanks!
