### PR TITLE
[#76] Fix the case where the param default is set to false

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -14,11 +14,11 @@ module Sinatra
     def param(name, type, options = {})
       name = name.to_s
 
-      return unless params.member?(name) or options[:default] or options[:required]
+      return unless params.member?(name) or !options[:default].nil? or options[:required]
 
       begin
         params[name] = coerce(params[name], type, options)
-        params[name] = (options[:default].call if options[:default].respond_to?(:call)) || options[:default] if params[name].nil? and options[:default]
+        params[name] = (options[:default].call if options[:default].respond_to?(:call)) || options[:default] if params[name].nil? and !options[:default].nil?
         params[name] = options[:transform].to_proc.call(params[name]) if params[name] and options[:transform]
         validate!(params[name], options)
       rescue InvalidParameterError => exception

--- a/spec/parameter_type_coercion_spec.rb
+++ b/spec/parameter_type_coercion_spec.rb
@@ -168,5 +168,21 @@ describe 'Parameter Types' do
         end
       end
     end
+
+    it 'coerces default booleans to true when default is true and its not provided' do
+      get('/default/boolean/true') do |response|
+        expect(response.status).to eql 200
+        expect(JSON.parse(response.body)['arg']).to be true
+        expect(JSON.parse(response.body)['arg']).to_not be_nil
+      end
+    end
+
+    it 'coerces default booleans to false when default is false and its not provided' do
+      get('/default/boolean/false') do |response|
+        expect(response.status).to eql 200
+        expect(JSON.parse(response.body)['arg']).to be false
+        expect(JSON.parse(response.body)['arg']).to_not be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello,

I submit this PR to fix the behaviour of the `boolean default param`
When the default is set to `false` the param is not present in the request, we get a `nil` instead of the `false`.

I hope you will consider this PR
