### PR TITLE
add a new param option: after_validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ param :y, String
 any_of :x, :y
 ```
 
+### after validation
+
+You can pass a ruby code block to `after_validation` option, it'll called after all validations passed. And In you head please know that this is a dangerous option, it'll cause some curious bugs if you modify the url params or do something else like this.
+
+```ruby
+param :order, String, in: ["ASC", "DESC"], after_validation: lambda { |order| puts "all validations of params[order] are passed" }
+```
+
 ### Exceptions
 
 By default, when a parameter precondition fails, `Sinatra::Param` will `halt 400` with an error message:
@@ -148,6 +156,8 @@ param :order, String, in: ["ASC", "DESC"], raise: true
 
 one_of :q, :categories, raise: true
 ```
+
+
 
 ## Contact
 

--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -21,6 +21,7 @@ module Sinatra
         params[name] = (options[:default].call if options[:default].respond_to?(:call)) || options[:default] if params[name].nil? and options[:default]
         params[name] = options[:transform].to_proc.call(params[name]) if params[name] and options[:transform]
         validate!(params[name], options)
+        options[:after_validation].to_proc.call(params[name]) if params[name] and options[:after_validation]
       rescue InvalidParameterError => exception
         if options[:raise] or (settings.raise_sinatra_param_exceptions rescue false)
           exception.param, exception.options = name, options

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -261,4 +261,10 @@ class App < Sinatra::Base
       message: 'OK'
     }.to_json
   end
+
+  get '/after_validation' do
+    param :a, String, after_validation: lambda { |a| params["b"] = a }
+
+    params.to_json
+  end
 end

--- a/spec/parameter_after_validation_spec.rb
+++ b/spec/parameter_after_validation_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+
+describe 'Parameter after_validation' do
+  describe 'default' do
+    it 'add a new params["b"] which has the same value as params["a] after validation passed' do
+      get('/after_validation', {a: "value_a"}) do |response|
+        expect(response.status).to eql 200
+        expect(JSON.parse(response.body)['b']).to eql 'value_a'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
I've added a new option `after_validation` to `param` to execute ruby block code after the validation passed.
Also, I updated the README file about the usage of it.