### PR TITLE
Coerce boolean regex anchor

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -100,7 +100,7 @@ module Sinatra
         return DateTime.parse(param) if type == DateTime
         return Array(param.split(options[:delimiter] || ",")) if type == Array
         return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
-        return (/(false|f|no|n|0)$/i === param.to_s ? false : (/(true|t|yes|y|1)$/i === param.to_s ? true : nil)) if type == TrueClass || type == FalseClass || type == Boolean
+        return (/^(false|f|no|n|0)$/i === param.to_s ? false : (/^(true|t|yes|y|1)$/i === param.to_s ? true : nil)) if type == TrueClass || type == FalseClass || type == Boolean
         return nil
       rescue ArgumentError
         raise InvalidParameterError, "'#{param}' is not a valid #{type}"

--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -100,7 +100,11 @@ module Sinatra
         return DateTime.parse(param) if type == DateTime
         return Array(param.split(options[:delimiter] || ",")) if type == Array
         return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
-        return (/^(false|f|no|n|0)$/i === param.to_s ? false : (/^(true|t|yes|y|1)$/i === param.to_s ? true : nil)) if type == TrueClass || type == FalseClass || type == Boolean
+        if [TrueClass, FalseClass, Boolean].include? type
+          coerced = /^(false|f|no|n|0)$/i === param.to_s ? false : /^(true|t|yes|y|1)$/i === param.to_s ? true : nil
+          raise ArgumentError if coerced.nil?
+          return coerced
+        end
         return nil
       rescue ArgumentError
         raise InvalidParameterError, "'#{param}' is not a valid #{type}"

--- a/spec/parameter_type_coercion_spec.rb
+++ b/spec/parameter_type_coercion_spec.rb
@@ -184,5 +184,19 @@ describe 'Parameter Types' do
         expect(JSON.parse(response.body)['arg']).to_not be_nil
       end
     end
+
+    it 'returns 400 on requests when true is not a truthy value' do
+      get('/default/boolean/true', arg: 'abc') do |response|
+        expect(response.status).to eql 400
+        expect(JSON.parse(response.body)['message']).to eq("'abc' is not a valid boolean")
+      end
+    end
+
+    it 'returns 400 on requests when false is not a falsey value' do
+      get('/default/boolean/false', arg: 'abc') do |response|
+        expect(response.status).to eql 400
+        expect(JSON.parse(response.body)['message']).to eq("'abc' is not a valid boolean")
+      end
+    end
   end
 end


### PR DESCRIPTION
Ran into a couple of small with boolean coercion that are address with this PR:

*  regexs were not properly anchored.  the result is that any string that ends with the params conventional truthy falsey values would be converted, ie the string 'nottrue' would be coerced to `true`.
*  when a boolean could not be coerced, params would return a nil.  for required boolean params the result is confusing:  'arg is required' although it was provided.  now a proper 'arg is not a boolean' message is returned.