### PR TITLE
add array within/in/range validate

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -129,9 +129,9 @@ module Sinatra
         when :in, :within, :range
           raise InvalidParameterError, "Parameter must be within #{value}" unless param.nil? || case value
           when Range
-            value.include?(param)
+            value.include?(param) || (Array(param) - Array(value).map(&:to_s)).empty?
           else
-            Array(value).include?(param)
+            Array(value).include?(param) || (Array(param) - Array(value)).empty?
           end
         when :min
           raise InvalidParameterError, "Parameter cannot be less than #{value}" unless param.nil? || value <= param

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -155,6 +155,11 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  get '/validation/array/in' do
+    param :arg, Array, in: ['ASC', 'DESC']
+    params.to_json
+  end
+
   get '/validation/within' do
     param :arg, Integer, within: 1..10
     params.to_json
@@ -162,6 +167,11 @@ class App < Sinatra::Base
 
   get '/validation/range' do
     param :arg, Integer, range: 1..10
+    params.to_json
+  end
+
+  get '/validation/array/range' do
+    param :arg, Array, range: 1..10
     params.to_json
   end
 

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -95,8 +95,21 @@ describe 'Parameter Validations' do
       end
     end
 
+    it 'returns 400 on requests with array value is not subset of the set' do
+      get('/validation/array/in', arg: 'ASC,MISC') do |response|
+        expect(response.status).to eq(400)
+        expect(JSON.parse(response.body)['message']).to eq("Parameter must be within [\"ASC\", \"DESC\"]")
+      end
+    end
+
     it 'returns 200 on requests with a value in the set' do
       get('/validation/in', arg: 'ASC') do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'returns 200 on requests with array value is subset of the set' do
+      get('/validation/array/in', arg: 'ASC,DESC') do |response|
         expect(response.status).to eq(200)
       end
     end
@@ -125,8 +138,21 @@ describe 'Parameter Validations' do
       end
     end
 
+    it 'returns 400 on requests with array value outside the range' do
+      get('/validation/array/range', arg: '1,7,9,11') do |response|
+        expect(response.status).to eq(400)
+        expect(JSON.parse(response.body)['message']).to eq("Parameter must be within 1..10")
+      end
+    end
+
     it 'returns 200 on requests within the range' do
       get('/validation/range', arg: 10) do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'returns 200 on requests within the range' do
+      get('/validation/array/range', arg: '1,7,9') do |response|
         expect(response.status).to eq(200)
       end
     end


### PR DESCRIPTION
improve param validation. 
```ruby
  get '/validation/within' do
    param :arg, Array, ['a', 'b', 'c']
    params.to_json
  end
```
Now: `get('/validation/within', arg: 'a,b') => response status 400`。
But some times need validate if Array param is in expected range.
So this PR wanna gots `get('/validation/within', arg: 'a,b') => response status 200`