### PR TITLE
Ensure the custom message is passed to a raised exception

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -23,12 +23,12 @@ module Sinatra
         validate!(params[name], options)
         params[name]
       rescue InvalidParameterError => exception
+        error = options[:message] || exception.to_s
+
         if options[:raise] or (settings.raise_sinatra_param_exceptions rescue false)
           exception.param, exception.options = name, options
-          raise exception
+          raise exception, error
         end
-
-        error = options[:message] || exception.to_s
 
         if content_type and content_type.match(mime_type(:json))
           error = {message: error, errors: {name => exception.message}}.to_json

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -271,6 +271,10 @@ class App < Sinatra::Base
     param :a, Integer, within: 1..10, required: true, message: "'a' must be less than 10"
   end
 
+  get '/raise/custommessage' do
+    param :a, Integer, within: 1..10, required: true, message: "'a' must be less than 10", raise: true
+  end
+
   get '/all_or_none_of' do
     param :a, String
     param :b, String

--- a/spec/parameter_raise_spec.rb
+++ b/spec/parameter_raise_spec.rb
@@ -22,4 +22,12 @@ describe 'Exception' do
       get('/raise/any_of', params)
     }.to raise_error Sinatra::Param::InvalidParameterError
   end
+
+  context 'custom message ' do
+    it 'returns a custom message in the raised error when configured' do
+      expect {
+        get('/raise/custommessage')
+      }.to raise_error Sinatra::Param::InvalidParameterError, /'a' must be less than 10/
+    end
+  end
 end


### PR DESCRIPTION
Currently the custom validation message isn't passed as the message to the raised exception. This pull request fixes that issue.