### PR TITLE
Add `File` as valid param type

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ By declaring parameter types, incoming parameters will automatically be transfor
 * `Array` _("1,2,3,4,5")_
 * `Hash` _(key1:value1,key2:value2)_
 * `Date`, `Time`, & `DateTime`
+* `File`
 
 ### Validations
 

--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -1,4 +1,5 @@
 require 'sinatra/base'
+require 'sinatra/param/uploaded_file'
 require 'sinatra/param/version'
 require 'date'
 require 'time'
@@ -121,6 +122,7 @@ module Sinatra
         return DateTime.parse(param) if type == DateTime
         return Array(param.split(options[:delimiter] || ",")) if type == Array
         return Hash[param.split(options[:delimiter] || ",").map{|c| c.split(options[:separator] || ":")}] if type == Hash
+        return UploadedFile.from_param(param) if type == File
         if [TrueClass, FalseClass, Boolean].include? type
           coerced = /^(false|f|no|n|0)$/i === param.to_s ? false : /^(true|t|yes|y|1)$/i === param.to_s ? true : nil
           raise ArgumentError if coerced.nil?

--- a/lib/sinatra/param/uploaded_file.rb
+++ b/lib/sinatra/param/uploaded_file.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Sinatra
+  module Param
+    # A wrapper/delegator to an uploaded file.
+    #
+    # The attributes are the same as the original parameter hash keys with
+    # extra aliases conforming to the `Rack::Multipart::UploadedFile` interface.
+    class UploadedFile < SimpleDelegator
+      attr_reader :filename, :head, :name, :tempfile, :type
+
+      def initialize(filename:, head:, name:, tempfile:, type:)
+        super(tempfile)
+        @filename = filename
+        @head = head
+        @name = name
+        @tempfile = tempfile
+        @type = type
+      end
+
+      alias content_type type
+      alias original_filename filename
+
+      def self.from_param(param)
+        new(
+          filename: param.fetch(:filename),
+          head: param.fetch(:head),
+          name: param.fetch(:name),
+          tempfile: param.fetch(:tempfile),
+          type: param.fetch(:type),
+        )
+      rescue KeyError, NoMethodError => e
+        raise ArgumentError, e.message
+      end
+    end
+  end
+end

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -70,6 +70,21 @@ class App < Sinatra::Base
     params.to_json
   end
 
+  put '/coerce/file' do
+    param :arg, File
+    {
+      arg: {
+        body: params[:arg].read,
+        content_type: params[:arg].content_type,
+        filename: params[:arg].filename,
+        head: params[:arg].head,
+        name: params[:arg].name,
+        original_filename: params[:arg].original_filename,
+        type: params[:arg].type,
+      },
+    }.to_json
+  end
+
   get '/coerce/boolean' do
     param :arg, Boolean
     params.to_json


### PR DESCRIPTION
With a type declaration of `File`, the input parameter hash of the uploaded
file is coerce into a new UploadedFile object which conforms to the
`Rack::Multipart::UploadedFile` interface.

The input parameter hash must be of the shape:
- `filename`: the original file name of the uploaded file
- `head`: the header lines of the multipart request
- `name`: the parameter name
- `tempfile`: the `Tempfile` created from the content of the multipart request
- `type`: the content media/MIME type

Fixes #103 