### PR TITLE
Explicitly stated what parameter caused the error

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -20,7 +20,7 @@ module Sinatra
         params[name] = coerce(params[name], type, options)
         params[name] = (options[:default].call if options[:default].respond_to?(:call)) || options[:default] if params[name].nil? and options.has_key?(:default)
         params[name] = options[:transform].to_proc.call(params[name]) if params[name] and options[:transform]
-        validate!(params[name], options)
+        validate!(params[name], options, name)
         params[name]
       rescue InvalidParameterError => exception
         if options[:raise] or (settings.raise_sinatra_param_exceptions rescue false)
@@ -132,13 +132,13 @@ module Sinatra
       end
     end
 
-    def validate!(param, options)
+    def validate!(param, options, name)
       options.each do |key, value|
         case key
         when :required
-          raise InvalidParameterError, "Parameter is required" if value && param.nil?
+          raise InvalidParameterError, "The parameter #{name} is required" if value && param.nil?
         when :blank
-          raise InvalidParameterError, "Parameter cannot be blank" if !value && case param
+          raise InvalidParameterError, "The parameter #{name} cannot be blank" if !value && case param
           when String
             !(/\S/ === param)
           when Array, Hash
@@ -147,25 +147,25 @@ module Sinatra
             param.nil?
           end
         when :format
-          raise InvalidParameterError, "Parameter must be a string if using the format validation" unless param.kind_of?(String)
-          raise InvalidParameterError, "Parameter must match format #{value}" unless param =~ value
+          raise InvalidParameterError, "The parameter #{name} must be a string if using the format validation" unless param.kind_of?(String)
+          raise InvalidParameterError, "The parameter #{name} must match format #{value}" unless param =~ value
         when :is
-          raise InvalidParameterError, "Parameter must be #{value}" unless param === value
+          raise InvalidParameterError, "The parameter #{name} must be #{value}" unless param === value
         when :in, :within, :range
-          raise InvalidParameterError, "Parameter must be within #{value}" unless param.nil? || case value
+          raise InvalidParameterError, "The parameter #{name} must be within #{value}" unless param.nil? || case value
           when Range
             value.include?(param)
           else
             Array(value).include?(param)
           end
         when :min
-          raise InvalidParameterError, "Parameter cannot be less than #{value}" unless param.nil? || value <= param
+          raise InvalidParameterError, "The parameter #{name} cannot be less than #{value}" unless param.nil? || value <= param
         when :max
-          raise InvalidParameterError, "Parameter cannot be greater than #{value}" unless param.nil? || value >= param
+          raise InvalidParameterError, "The parameter #{name} cannot be greater than #{value}" unless param.nil? || value >= param
         when :min_length
-          raise InvalidParameterError, "Parameter cannot have length less than #{value}" unless param.nil? || value <= param.length
+          raise InvalidParameterError, "The parameter #{name} cannot have length less than #{value}" unless param.nil? || value <= param.length
         when :max_length
-          raise InvalidParameterError, "Parameter cannot have length greater than #{value}" unless param.nil? || value >= param.length
+          raise InvalidParameterError, "The parameter #{name} cannot have length greater than #{value}" unless param.nil? || value >= param.length
         end
       end
     end

--- a/spec/parameter_transformations_spec.rb
+++ b/spec/parameter_transformations_spec.rb
@@ -35,7 +35,7 @@ describe 'Parameter Transformations' do
     it 'skips transformations when the value is nil' do
       get('/transform/required') do |response|
         expect(response.status).to eql 400
-        expect(JSON.parse(response.body)['message']).to eq("Parameter is required")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter order is required")
       end
     end
   end

--- a/spec/parameter_validations_spec.rb
+++ b/spec/parameter_validations_spec.rb
@@ -5,7 +5,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests without required fields' do
       get('/validation/required') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter is required")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg is required")
       end
     end
 
@@ -20,28 +20,28 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests when string is blank' do
       get('/validation/blank/string', arg: '') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be blank")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot be blank")
       end
     end
 
     it 'returns 400 on requests when array is blank' do
       get('/validation/blank/array', arg: '') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be blank")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot be blank")
       end
     end
 
     it 'returns 400 on requests when hash is blank' do
       get('/validation/blank/hash', arg: '') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be blank")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot be blank")
       end
     end
 
     it 'returns 400 on requests when hash is blank' do
       get('/validation/blank/other', arg: '') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be blank")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot be blank")
       end
     end
 
@@ -76,7 +76,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests when value is other than defined' do
       get('/validation/is', arg: 'bar') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter must be foo")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg must be foo")
       end
     end
 
@@ -91,7 +91,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a value not in the set' do
       get('/validation/in', arg: 'MISC') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter must be within [\"ASC\", \"DESC\"]")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg must be within [\"ASC\", \"DESC\"]")
       end
     end
 
@@ -106,7 +106,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a value outside the range' do
       get('/validation/within', arg: 20) do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter must be within 1..10")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg must be within 1..10")
       end
     end
 
@@ -121,7 +121,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a value outside the range' do
       get('/validation/range', arg: 20) do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter must be within 1..10")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg must be within 1..10")
       end
     end
 
@@ -136,7 +136,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a value smaller than min' do
       get('/validation/min', arg: 5) do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be less than 12")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot be less than 12")
       end
     end
 
@@ -151,7 +151,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a value larger than max' do
       get('/validation/max', arg: 100) do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot be greater than 20")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot be greater than 20")
       end
     end
 
@@ -166,7 +166,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a string shorter than min_length' do
       get('/validation/min_length', arg: 'hi') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot have length less than 5")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot have length less than 5")
       end
     end
 
@@ -181,7 +181,7 @@ describe 'Parameter Validations' do
     it 'returns 400 on requests with a string longer than max_length' do
       get('/validation/max_length', arg: 'reallylongstringlongerthanmax') do |response|
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)['message']).to eq("Parameter cannot have length greater than 10")
+        expect(JSON.parse(response.body)['message']).to eq("The parameter arg cannot have length greater than 10")
       end
     end
 


### PR DESCRIPTION
Previously the error would read, "Parameter cannot be less ... " but this is not helpful as it is too generic and could be from any of the parameters.
I added name field to the function validate!(param, options, name) then it is called as validate!(params[name], options, name) inside the def param function. The error message is updated inside the validation function as "The parameter #{name} ... "
since name is already supported there.